### PR TITLE
Fix JLab padding, remove debug value

### DIFF
--- a/app.ipynb
+++ b/app.ipynb
@@ -174,6 +174,7 @@
     "    py = [p.point.elevation for p in points]\n",
     "    \n",
     "    x_scale, y_scale = LinearScale(), LinearScale()\n",
+    "    x_scale.allow_padding = False\n",
     "    x_ax = Axis(label='Distance (km)', scale=x_scale)\n",
     "    y_ax = Axis(label='Elevation (m)', scale=y_scale, orientation='vertical')\n",
     "    \n",

--- a/app.ipynb
+++ b/app.ipynb
@@ -243,7 +243,6 @@
     "            trace.center = marker.location\n",
     "        \n",
     "        position = max(0, int((selected / distance_from_start) * len(points)))\n",
-    "        debug.value = str(position) + \" \" + str(distance_from_start)\n",
     "        \n",
     "    brushintsel.observe(update_range, 'selected')"
    ]


### PR DESCRIPTION
### Changes

- Fix padding when hovering on the elevation graph. Use the `allow_padding=False` flag as mentioned in https://github.com/bloomberg/bqplot/issues/767
- Remove the debug value, but keep the debug label for now