### PR TITLE
Handle traces without time data

### DIFF
--- a/app.ipynb
+++ b/app.ipynb
@@ -147,10 +147,12 @@
     "    stat_layout = Layout(margin=\"10px\", padding=\"10px\", border=\"1px solid black\",\n",
     "                         flex_flow='column', align_items='center')\n",
     "    \n",
+    "    start_time = gpx.get_time_bounds().start_time\n",
+    "    duration = gpx.get_duration()\n",
     "    stats = [\n",
-    "        ('Date', gpx.get_time_bounds().start_time.strftime(\"%Y-%m-%d\")),\n",
+    "        ('Date', start_time.strftime(\"%Y-%m-%d\") if start_time else '-'),\n",
     "        ('Distance', f\"{round(distance_from_start / 1000, 2)} km\"),\n",
-    "        ('Duration', str(datetime.timedelta(seconds=gpx.get_duration()))),\n",
+    "        ('Duration', str(datetime.timedelta(seconds=duration)) if duration else '-'),\n",
     "        ('Lowest', f\"{int(lowest)} m\"),\n",
     "        ('Highest', f\"{int(highest)} m\"),\n",
     "        ('Uphill', f\"{int(uphill)} m\"),\n",
@@ -379,6 +381,13 @@
    "source": [
     "out"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -397,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.3"
   },
   "title": "GPX Viewer"
  },


### PR DESCRIPTION
Some gpx files don't have time data.

For example this one: https://www.wanderkompass.de/category/1100-66-seen-wanderweg.html?download=15790

From: https://www.wanderkompass.de/66-Seen-Wanderweg/66-Seen-Wanderweg-Etappe-11.html

![image](https://user-images.githubusercontent.com/591645/86963139-55e23580-c164-11ea-958e-862c0267f2a6.png)
