### PR TITLE
Update dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,9 @@ channels:
 dependencies:
 - bqplot=0.12
 - ipyleaflet=0.13
-- ipywidgets=7.5
-- jupyterlab=2
+- ipywidgets=7.6
+- jupyterlab=3
 - nodejs
 - gpxpy=1.4
 - srtm.py=0.3.4
-- voila=0.1.21
+- voila=0.2

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,0 @@
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet bqplot


### PR DESCRIPTION
Update a couple of dependencies, and remove the `postBuild` file since it is not required anymore (extensions use the new distribution in JupyterLab 3.0)