### PR TITLE
voila-gpx-viewer environment settings upgraded to new and still supported packages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Experimental GPX Viewer web app built with Jupyter, ipywidgets, ipyleaflet, bqpl
 
 ## Usage
 
-Create the environment with the dependencies:
+#In order to generate the proper conda environment, type the following two lines
 
-```bash
-conda env create
+conda create --name voila-gpx-viewer python=3.10
 conda activate voila-gpx-viewer
-```
+
+#than run this file just by typing 
+
+#bash inst.sh
 
 Open the app:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ activate the created environment
 conda activate voila-gpx-viewer
 ```
 
-run the bash.sh file 
+install the right version for each package by running inst.sh
 
 ```
 bash inst.sh
@@ -29,5 +29,5 @@ bash inst.sh
 Open the app:
 
 ```
-bash voila app.ipynb
+voila app.ipynb
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Experimental GPX Viewer web app built with Jupyter, ipywidgets, ipyleaflet, bqpl
 
 ## Usage
 
-generate a proper conda environment just by typing
+Do not use the environment.yml file, but go ahead with the following steps:
+
+Generate a proper conda environment just by typing
 
 ```
 conda create --name voila-gpx-viewer python=3.10

--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@ Experimental GPX Viewer web app built with Jupyter, ipywidgets, ipyleaflet, bqpl
 
 ## Usage
 
-#In order to generate the proper conda environment, type the following two lines
+In order to generate the proper conda environment, type the following two lines
 
+```
 conda create --name voila-gpx-viewer python=3.10
+```
+
+```
 conda activate voila-gpx-viewer
+```
 
-#than run this file just by typing 
+than run this file just by typing 
 
-#bash inst.sh
+bash inst.sh
 
 Open the app:
 

--- a/README.md
+++ b/README.md
@@ -8,22 +8,26 @@ Experimental GPX Viewer web app built with Jupyter, ipywidgets, ipyleaflet, bqpl
 
 ## Usage
 
-In order to generate the proper conda environment, type the following two lines
+generate a proper conda environment just by typing
 
 ```
 conda create --name voila-gpx-viewer python=3.10
 ```
 
+activate the created environment
+
 ```
 conda activate voila-gpx-viewer
 ```
 
-than run this file just by typing 
+run the bash.sh file 
 
+```
 bash inst.sh
+```
 
 Open the app:
 
-```bash
-voila app.ipynb
+```
+bash voila app.ipynb
 ```

--- a/app.ipynb
+++ b/app.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,9 +36,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6c8100870a34e5dbe9c501621dd6b04",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Powered by:'), Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x00N\\x00\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "tools = [\"voila\", \"ipyleaflet\", \"ipywidgets\", \"bqplot\"]\n",
     "logos = []\n",
@@ -52,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,9 +210,7 @@
     "    \n",
     "    lines = Lines(x=px, y=py, scales={'x': x_scale, 'y': y_scale})\n",
     "    \n",
-    "    elevation = Figure(title='Elevation Chart', axes=[x_ax, y_ax], marks=[lines])#,\\\n",
-    "    #                   labels=['blabla'])#legend_text = 'that s a text')\n",
-    "    #legend()\n",
+    "    elevation = Figure(title='Elevation Chart', axes=[x_ax, y_ax], marks=[lines])\n",
     "    \n",
     "    elevation.layout.width = 'auto'\n",
     "    elevation.layout.height = 'auto'\n",
@@ -210,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,13 +305,18 @@
     "        for p in segment.points:\n",
     "            points.append({\n",
     "                'time': p.time,\n",
-    "                #'latitude': p.latitude,\n",
-    "                #'longitude': p.longitude,\n",
-    "                #'elevation': p.elevation,\n",
+    "                'latitude': p.latitude,\n",
+    "                'longitude': p.longitude,\n",
+    "                'elevation': p.elevation,\n",
     "            })\n",
     "    coords = pd.DataFrame.from_records(points)\n",
-    "    \n",
-    "    print(coords.head())\n",
+    "\n",
+    "    space = ( coords['latitude']**2 + coords['longitude']**2 + coords['elevation']**2 )**.5\n",
+    "    #time = pd.to_timedelta(coords['time']).dt.total_seconds()\n",
+    "    #speed = space/coords['time']\n",
+    "    print( coords['time'])\n",
+    "    print('\\n')\n",
+    "    print( coords['time'].astype(int) )\n",
     "    return coords"
    ]
   },

--- a/app.ipynb
+++ b/app.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,17 +24,36 @@
     "import gpxpy\n",
     "import srtm\n",
     "\n",
-    "from bqplot import Axis, Figure, Lines, LinearScale\n",
+    "from bqplot import Axis, Figure, Lines, LinearScale#, legend\n",
     "from bqplot.interacts import IndexSelector\n",
-    "from ipyleaflet import basemaps, FullScreenControl, LayerGroup, Map, MeasureControl, Polyline, Marker, CircleMarker, WidgetControl\n",
-    "from ipywidgets import Button, HTML, HBox, VBox, Checkbox, FileUpload, Label, Output, IntSlider, Layout, Image, link"
+    "from ipyleaflet import basemaps, FullScreenControl, LayerGroup, Map, MeasureControl, \\\n",
+    "    Polyline, Marker, CircleMarker, WidgetControl\n",
+    "from ipywidgets import Button, HTML, HBox, VBox, Checkbox, FileUpload, Label, Output,\\\n",
+    "    IntSlider, Layout, Image, link\n",
+    "\n",
+    "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e1edbdb6485c407d8c26d69ea669b447",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Powered by:'), Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x00N\\x00\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "tools = [\"voila\", \"ipyleaflet\", \"ipywidgets\", \"bqplot\"]\n",
     "logos = []\n",
@@ -48,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +210,10 @@
     "    \n",
     "    lines = Lines(x=px, y=py, scales={'x': x_scale, 'y': y_scale})\n",
     "    \n",
-    "    elevation = Figure(title='Elevation Chart', axes=[x_ax, y_ax], marks=[lines])\n",
+    "    elevation = Figure(title='Elevation Chart', axes=[x_ax, y_ax], marks=[lines])#,\\\n",
+    "    #                   labels=['blabla'])#legend_text = 'that s a text')\n",
+    "    #legend()\n",
+    "    \n",
     "    elevation.layout.width = 'auto'\n",
     "    elevation.layout.height = 'auto'\n",
     "    elevation.layout.min_height = '300px'\n",
@@ -203,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,12 +299,27 @@
     "    display(elevation)\n",
     "    display(debug)\n",
     "    \n",
-    "    link_trace_elevation(trace, elevation, gpx, debug)"
+    "    link_trace_elevation(trace, elevation, gpx, debug)\n",
+    "    \n",
+    "    j = 0\n",
+    "    points = []\n",
+    "    for segment in gpx.tracks[j].segments:\n",
+    "        for p in segment.points:\n",
+    "            points.append({\n",
+    "                'time': p.time,\n",
+    "                #'latitude': p.latitude,\n",
+    "                #'longitude': p.longitude,\n",
+    "                #'elevation': p.elevation,\n",
+    "            })\n",
+    "    coords = pd.DataFrame.from_records(points)\n",
+    "    \n",
+    "    print(coords.head())\n",
+    "    return coords"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,9 +374,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d10a6f01a534bb9b83d65ac9b9ffa47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FileUpload(value={}, accept='.gpx', description='Upload')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_uploader()"
    ]
@@ -355,16 +407,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "38b3881ebb544c57838a9fccab61a6ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Button(description='signal-forbes', style=ButtonStyle()), Button(description='refuge-albert-1er…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_examples()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,19 +442,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c69b7e476c7e4fe18200f8b92b26937a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "out"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -406,7 +481,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.12"
   },
   "title": "GPX Viewer"
  },

--- a/app.ipynb
+++ b/app.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,24 +36,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e1edbdb6485c407d8c26d69ea669b447",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Label(value='Powered by:'), Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x00N\\x00\\…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tools = [\"voila\", \"ipyleaflet\", \"ipywidgets\", \"bqplot\"]\n",
     "logos = []\n",
@@ -67,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,24 +359,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d10a6f01a534bb9b83d65ac9b9ffa47",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "FileUpload(value={}, accept='.gpx', description='Upload')"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_uploader()"
    ]
@@ -407,31 +377,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "38b3881ebb544c57838a9fccab61a6ca",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Button(description='signal-forbes', style=ButtonStyle()), Button(description='refuge-albert-1er…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_examples()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,24 +397,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c69b7e476c7e4fe18200f8b92b26937a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "out"
    ]

--- a/inst.sh
+++ b/inst.sh
@@ -1,0 +1,21 @@
+#In order to generate the proper conda environment, type the following two lines
+
+#conda create --name voila-gpx-viewer python=3.10
+#conda activate voila-gpx-viewer
+
+#than run this file just by typing 
+
+#bash inst.sh
+#cazzarola!
+
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+pip install jinja2==3.0.3
+pip install bqplot==0.12
+pip install ipyleaflet==0.17.3
+pip install ipywidgets==7.7.5
+pip install jupyterlab==3.4.0
+pip install gpxpy==1.5
+pip install srtm.py==0.3.7
+pip install voila==0.3


### PR DESCRIPTION
The voila-gpx-viewer you have written seems not to be supported anymore, as I remember it was properly working few months ago and it does not work in none of the two newly installed Anaconda distributions I recently used on my laptop (I've used an Ubuntu Linux distribution before and now a Linux Mint one). 

Particularly, running the "environment.yml" file via conda, nothing is going to be upgraded anymore and the software does not work at all.

Basically, the job I did here makes voila-gpx-viewer available again, also on newly installed Anaconda distributions.

To do that, I've added a "inst.sh" file which  basically makes the job of the "environment.yml" (which is still present in between the files and I believe it could be deleted) you've written before. 

In the README.md file, also modified, I explain how to set up the new environment using the "inst.sh file; the "environment.yml" can be ignored at all.

Mostly, the difference between my "inst.sh" and your "environment.yml" file is that I've replaced the "conda" lines of code with "pip" ones. Furthermore the "inst.sh" file provides packages versions which are not the some as the "environment.yml" ones.  
Particularly, the altimetry data seem to come from a web source which is not available anymore on the some link as before. For this reason I've repleced the srtm.py package with the upgraded one, which is 0.3.7 and takes altimetry data from the right links (without showing any message of error!). 

Consider this is my second Pull request ever. The first one I did almost one year ago, where I was training on Git and GitHub and you gently accepted my request of doing my first pull request ever.
Fill free to suggest me any further modification.

Waiting for a your answer, I thank you for your attention